### PR TITLE
Patch 1

### DIFF
--- a/paypal.php
+++ b/paypal.php
@@ -533,7 +533,7 @@ class PayPal extends PaymentModule
         $form = $helper->generateForm($fields_form);
 
 
-        if (count($this->errors)) {
+        if (count((array)$this->errors)) {
             $this->message .= $this->errors;
         } elseif (Configuration::get('PAYPAL_METHOD') && Configuration::get('PAYPAL_SANDBOX') == 1) {
             if (Configuration::get('PAYPAL_METHOD') == 'BT') {


### PR DESCRIPTION
Fixes a bug in PHP 7.2 
Warning in Line 536 of File [...]/modules/paypal/paypal.php [2] count(): Parameter must be an array or an object that implements Countable

added "(array)"
error is gone ;)

I am new to github, so sorry if i made this comment not correctly :)