### PR TITLE
refs #39949 warning on diagnostic page

### DIFF
--- a/vendor/ppbtlib/src/Utils/CacheStorage/CacheStorage.php
+++ b/vendor/ppbtlib/src/Utils/CacheStorage/CacheStorage.php
@@ -177,9 +177,9 @@ class CacheStorage
      */
     public function set($key, $content, $params = [], $optional = [])
     {
-        $content = str_replace(['<?php', '<?', '?>'], '', $content);
         $fileName = $this->getKeyFileName($key);
         $content = $this->buildCacheContent($content, $params, $optional);
+        $content = str_replace(['<?php', '<?', '?>'], '', $content);
         $filename = $fileName . uniqid('', true) . '.tmp';
         $dateGeneration = date('Y-m-d H:i:s');
         file_put_contents($filename, "<?php\r\r//Generated $dateGeneration\r\rreturn " . $content . ';', LOCK_EX);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | There is a warning on a diagnostic page if PHP version 8.x
| Type?         | bug fix
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
