### PR TITLE
Fix: The quantities in stock are not verified in case of payment with PayPal

### DIFF
--- a/202/_dev/js/shortcut.js
+++ b/202/_dev/js/shortcut.js
@@ -127,11 +127,13 @@ const Shortcut = {
       createOrder: async function(data, actions) {
         let result = await Shortcut.checkCartStillOrderable();
 
-        if (!result) {
-          window.location.reload();
-        } else {
+        if (result) {
           return Shortcut.getIdOrder();
         }
+      },
+
+      onError(err) {
+        window.location.reload();
       },
 
       onApprove: function(data, actions) {

--- a/202/_dev/js/shortcut.js
+++ b/202/_dev/js/shortcut.js
@@ -124,8 +124,14 @@ const Shortcut = {
 
       style: Shortcut.getStyleSetting(),
 
-      createOrder: function(data, actions) {
-        return Shortcut.getIdOrder();
+      createOrder: async function(data, actions) {
+        let result = await Shortcut.checkCartStillOrderable();
+
+        if (!result) {
+          window.location.reload();
+        } else {
+          return Shortcut.getIdOrder();
+        }
       },
 
       onApprove: function(data, actions) {
@@ -275,6 +281,36 @@ const Shortcut = {
     if (mark.isEligible()) {
       mark.render(markContainer);
     }
+  },
+
+  checkCartStillOrderable() {
+    let data = new Object();
+    let url = new URL(this.controller);
+    url.searchParams.append('ajax', '1');
+    url.searchParams.append('action', 'CheckAvailability');
+    this.updateInfo();
+    data['page'] = this.page;
+    data['sc'] = true;
+
+    if (this.page == 'product') {
+      data['idProduct'] = this.idProduct;
+      data['quantity'] = this.productQuantity;
+      data['combination'] = this.combination.join('|');
+      data['sc'] = true;
+    }
+
+    return fetch(url.toString(),
+      {
+        method: 'post',
+        headers: {
+          'content-type': 'application/json;charset=utf-8'
+        },
+        body: JSON.stringify(data),
+      }).then(function(res){
+        return res.json();
+    }).then(function (json) {
+      return json.success;
+    });
   }
 
 };

--- a/controllers/front/ScInit.php
+++ b/controllers/front/ScInit.php
@@ -62,6 +62,7 @@ class PaypalScInitModuleFrontController extends PaypalAbstarctModuleFrontControl
 
         switch ($request->page) {
             case 'cart':
+            case 'payment-step':
                 if ($this->context->cart->checkQuantities() && $this->context->cart->nbProducts()) {
                     $this->jsonValues = ['success' => true];
                 } else {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | As the remaining quantity in stock is not checked when paying with PayPal or other forms that require a gateway payment, it is possible to complete the order and pay for an out-of-stock product even if this is not permitted.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #325
| How to test?  | 1 - Create a cart with an available item. 2 - Proceed to checkout until the payment selection. 3 - Before confirming the order, modify the product quantity in the admin, making it unavailable. 4 - Confirm the order with PayPal. 5 - The system should refresh the page and redirect to the cart.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
