### PR TITLE
refs #51013 actionPaypalShippingInfo hook

### DIFF
--- a/services/Builder/OrderCreateBody.php
+++ b/services/Builder/OrderCreateBody.php
@@ -35,6 +35,7 @@ use Address;
 use Configuration;
 use Context;
 use Customer;
+use Hook;
 use Module;
 use Paypal;
 use PaypalAddons\classes\AbstractMethodPaypal;
@@ -378,6 +379,14 @@ class OrderCreateBody implements BuilderInterface
         if (false == empty($name)) {
             $shippingInfo['name'] = $name;
         }
+
+        Hook::exec(
+            'actionPaypalShippingInfo',
+            [
+                'shippingInfo' => &$shippingInfo,
+                'cart' => $this->context->cart,
+            ]
+        );
 
         return $shippingInfo;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the Paypal PrestaShop addons project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | actionPaypalShippingInfo hook is added to enable a third-part modify shipping information sent to PayPal 
| Type?         | improvement
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes #{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
