### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,5 +1,7 @@
 name: Coding Standart
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
     # Check there is no syntax errors in the project
     php-linter:


### PR DESCRIPTION
Potential fix for [https://github.com/202ecommerce/paypal/security/code-scanning/3](https://github.com/202ecommerce/paypal/security/code-scanning/3)

In general, fix this by adding an explicit `permissions` block that grants only the minimal required scopes. Since this workflow appears to only need to read repository contents (for checkout and analysis), `contents: read` at the workflow root is sufficient and will apply to all jobs.

Concretely, edit `.github/workflows/php.yml` to insert a `permissions:` block near the top (after the `name:` or `on:` keys). Use `contents: read` as a minimal starting point. No other changes to the jobs or steps are needed, and no imports or extra methods are required because this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
