### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,5 +1,7 @@
 name: Unit test
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
     # Run PHPUnit against the module and a PrestaShop release
     phpunit:


### PR DESCRIPTION
Potential fix for [https://github.com/202ecommerce/paypal/security/code-scanning/4](https://github.com/202ecommerce/paypal/security/code-scanning/4)

In general, the fix is to explicitly add a `permissions` block that grants only the minimal rights the workflow needs, either at the root of the workflow (applies to all jobs) or at the job level. For a unit-test workflow that only checks out code, uses caches, runs composer, and runs tests inside Docker, read-only repository access is sufficient; usually `contents: read` is enough, and no write scopes are necessary.

For this specific file, `.github/workflows/phpunit.yml`, the simplest, non-breaking fix is to add a `permissions` section at the workflow root (top level, alongside `name` and `on`). This will automatically apply to the `phpunit` job. We’ll set `contents: read`, which aligns with CodeQL’s minimal suggestion and is compatible with `actions/checkout` and `actions/cache`. No additional imports or dependencies are required, and no existing steps need to change. The change should go after line 2 (`on: [pull_request]`) to keep the YAML structure clear.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
