### PR TITLE
Fix payment options not displayed in guest checkout

### DIFF
--- a/paypal.php
+++ b/paypal.php
@@ -854,10 +854,6 @@ class PayPal extends PaymentModule implements WidgetInterface
         if (Module::isEnabled('braintreeofficial') && (int) Configuration::get('BRAINTREEOFFICIAL_ACTIVATE_PAYPAL')) {
             return [];
         }
-        if (false === $this->context->customer->isLogged(true)) {
-            return [];
-        }
-
         $isoCountryDefault = Country::getIsoById((int) Configuration::get('PS_COUNTRY_DEFAULT'));
         $payments_options = [];
         $method = AbstractMethodPaypal::load();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Guest checkout: all PayPal payment options are hidden since the customer check in `hookPaymentOptions` was tightened in 33e39ed2 (released with 6.7.x). <br>
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Related to #329.
| How to test?  | 1. PrestaShop 1.7.x, module 6.7.1, a one-page checkout module (e.g. Knowband SuperCheckout) and guest checkout enabled. <br> 2. As a guest (not logged in), add a product

